### PR TITLE
Change users fetch strategy

### DIFF
--- a/lib/senkosan.ex
+++ b/lib/senkosan.ex
@@ -4,7 +4,7 @@ defmodule Senkosan do
   use Application
 
   def start(_type, _args) do
-    init_voice_state()
+    Senkosan.VoiceState.init()
 
     children = [
       {Senkosan.Consumer, []}
@@ -12,12 +12,5 @@ defmodule Senkosan do
 
     opts = [strategy: :one_for_one, name: Senkosan.Supervisor]
     Supervisor.start_link(children, opts)
-  end
-
-  def init_voice_state() do
-    Nostrum.Api.get_current_user_guilds!()
-    |> hd()
-    |> Map.fetch!(:id)
-    |> Senkosan.VoiceState.init()
   end
 end

--- a/lib/senkosan/voice_state.ex
+++ b/lib/senkosan/voice_state.ex
@@ -39,7 +39,7 @@ defmodule Senkosan.VoiceState do
   @spec process_transition(map) :: atom
   def process_transition(%{channel_id: new_channel_id, user_id: user_id} = _) do
     default_voice_channel = Application.get_env(:senkosan, :default_voice_channel)
-    user = :ets.lookup_element(@table_name, user_id, 2)
+    user = get_user(user_id)
 
     trig_time =
       DateTime.utc_now()
@@ -66,6 +66,14 @@ defmodule Senkosan.VoiceState do
         :ets.update_element(@table_name, user_id, {2, new_user_attr})
         :other_transition
     end
+  end
+
+  @doc """
+  Returns user attributes from ETS table.
+  In case the user doesn't exist, create it by fetching with discord API
+  """
+  def get_user(user_id) do
+    :ets.lookup_element(@table_name, user_id, 2)
   end
 
   @doc """

--- a/lib/senkosan/voice_state.ex
+++ b/lib/senkosan/voice_state.ex
@@ -80,7 +80,7 @@ defmodule Senkosan.VoiceState do
     |> Map.fetch!(:id)
   end
 
-  defp format_user_attrs(user) do
+  defp format_user_attrs(%{user: user}) do
     %__MODULE__{
       name: user.username,
       is_bot: if(user.bot, do: user.bot, else: false)

--- a/lib/senkosan/voice_state.ex
+++ b/lib/senkosan/voice_state.ex
@@ -15,7 +15,6 @@ defmodule Senkosan.VoiceState do
 
   @doc """
   Creates a table to contain the voice states and insertes user states.
-  Each user state is fetched by Discord guild member list API
   """
   @spec init() :: :ok
   def init() do

--- a/lib/senkosan/voice_state.ex
+++ b/lib/senkosan/voice_state.ex
@@ -63,12 +63,15 @@ defmodule Senkosan.VoiceState do
   """
   def get_user(user_id) do
     case :ets.lookup(@table_name, user_id) do
-      [{_, user}] -> user
+      [{_, user}] ->
+        user
+
       [] ->
         user_attrs =
           get_guild_id()
           |> Api.get_guild_member!(user_id)
           |> format_user_attrs()
+
         :ets.insert(@table_name, {user_id, user_attrs})
         user_attrs
     end

--- a/lib/senkosan/voice_state.ex
+++ b/lib/senkosan/voice_state.ex
@@ -17,21 +17,9 @@ defmodule Senkosan.VoiceState do
   Creates a table to contain the voice states and insertes user states.
   Each user state is fetched by Discord guild member list API
   """
-  @spec init(integer) :: :ok
-  def init(guild_id) do
+  @spec init() :: :ok
+  def init() do
     :ets.new(@table_name, [:ordered_set, :public, :named_table])
-
-    guild_id
-    |> Api.list_guild_members!(limit: 1000)
-    |> Enum.each(fn %{user: user} ->
-      attrs = %__MODULE__{
-        name: user.username,
-        is_bot: if(user.bot, do: user.bot, else: false)
-      }
-
-      :ets.insert(@table_name, {user.id, attrs})
-    end)
-
     :ok
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Senkosan.MixProject do
   def project do
     [
       app: :senkosan,
-      version: "0.0.3",
+      version: "0.0.4",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps()

--- a/test/senkosan/voice_state_test.exs
+++ b/test/senkosan/voice_state_test.exs
@@ -7,7 +7,7 @@ defmodule Senkosan.VoiceStateTest do
   @table_name :senkosan_voice_state
 
   describe "init/1 " do
-    test "creates voice_state table on ETS and inserts the formatted user attributes" do
+    test "creates voice_state table on ETS" do
       guild_id = 123
       users = UserFactory.build_pair(:guild_member)
       :meck.expect(Nostrum.Api, :list_guild_members!, fn ^guild_id, limit: 1000 -> users end)

--- a/test/senkosan/voice_state_test.exs
+++ b/test/senkosan/voice_state_test.exs
@@ -9,19 +9,8 @@ defmodule Senkosan.VoiceStateTest do
 
   describe "init/1 " do
     test "creates voice_state table on ETS" do
-      guild_id = 123
-      users = UserFactory.build_pair(:guild_member)
-      :meck.expect(Api, :list_guild_members!, fn ^guild_id, limit: 1000 -> users end)
-
-      expected =
-        users
-        |> Enum.map(fn %{user: user} ->
-          {user.id, %VoiceState{name: user.username, is_bot: user.bot}}
-        end)
-        |> Enum.sort_by(&elem(&1, 0))
-
-      assert VoiceState.init(guild_id) == :ok
-      assert List.flatten(:ets.match(@table_name, :"$1")) == expected
+      assert VoiceState.init() == :ok
+      refute :ets.whereis(@table_name) == :undefined
     end
   end
 

--- a/test/senkosan/voice_state_test.exs
+++ b/test/senkosan/voice_state_test.exs
@@ -133,10 +133,12 @@ defmodule Senkosan.VoiceStateTest do
 
     test "returns user attributes in ETS table" do
       user_id = 1
+
       attrs = %VoiceState{
-        name:   "someone",
-        is_bot: false,
+        name: "someone",
+        is_bot: false
       }
+
       :ets.insert(@table_name, {user_id, attrs})
 
       assert VoiceState.get_user(user_id) == attrs
@@ -145,15 +147,16 @@ defmodule Senkosan.VoiceStateTest do
     test "returns user attributes fetched by discord API in case ETS table doesn't have the user" do
       guild_member = UserFactory.build(:guild_member)
       user_id = guild_member.user.id
+
       expected = %VoiceState{
-        name:   guild_member.user.username,
-        is_bot: guild_member.user.bot,
+        name: guild_member.user.username,
+        is_bot: guild_member.user.bot
       }
 
       guilds = [GuildFactory.build(:guild)]
       guild_id = Map.fetch!(hd(guilds), :id)
       :meck.expect(Api, :get_current_user_guilds!, fn -> guilds end)
-      :meck.expect(Api, :get_guild_member!, fn (^guild_id, ^user_id) -> guild_member end)
+      :meck.expect(Api, :get_guild_member!, fn ^guild_id, ^user_id -> guild_member end)
 
       VoiceState.get_user(user_id)
       assert VoiceState.get_user(user_id) == expected

--- a/test/senkosan/voice_state_test.exs
+++ b/test/senkosan/voice_state_test.exs
@@ -135,6 +135,24 @@ defmodule Senkosan.VoiceStateTest do
     end
   end
 
+  describe "get_user/1" do
+    setup do
+      :ets.new(@table_name, [:ordered_set, :protected, :named_table])
+      :ok
+    end
+
+    test "returns user attributes in ETS table" do
+      user_id = 1
+      attrs = %VoiceState{
+        name:   "someone",
+        is_bot: false,
+      }
+      :ets.insert(@table_name, {user_id, attrs})
+
+      assert VoiceState.get_user(user_id) == attrs
+    end
+  end
+
   describe "bot_user?/1 " do
     setup do
       :ets.new(@table_name, [:ordered_set, :protected, :named_table])

--- a/test/senkosan/voice_state_test.exs
+++ b/test/senkosan/voice_state_test.exs
@@ -143,17 +143,17 @@ defmodule Senkosan.VoiceStateTest do
     end
 
     test "returns user attributes fetched by discord API in case ETS table doesn't have the user" do
-      user = UserFactory.build(:user)
-      user_id = user.id
+      guild_member = UserFactory.build(:guild_member)
+      user_id = guild_member.user.id
       expected = %VoiceState{
-        name:   user.username,
-        is_bot: user.bot,
+        name:   guild_member.user.username,
+        is_bot: guild_member.user.bot,
       }
 
       guilds = [GuildFactory.build(:guild)]
       guild_id = Map.fetch!(hd(guilds), :id)
       :meck.expect(Api, :get_current_user_guilds!, fn -> guilds end)
-      :meck.expect(Api, :get_guild_member!, fn (^guild_id, ^user_id) -> user end)
+      :meck.expect(Api, :get_guild_member!, fn (^guild_id, ^user_id) -> guild_member end)
 
       VoiceState.get_user(user_id)
       assert VoiceState.get_user(user_id) == expected


### PR DESCRIPTION
Change users fetch strategy. The reason for that is the following.

- To avoid to use list_guild_member API. (It returns 403 now)
- To fetch the attributes of the new comers.